### PR TITLE
Add `publishDate` as a default field

### DIFF
--- a/packages/gatsby-theme-basic/src/@whitespace/gatsby-plugin-search/backend/minisearch/useSearchDocuments.js
+++ b/packages/gatsby-theme-basic/src/@whitespace/gatsby-plugin-search/backend/minisearch/useSearchDocuments.js
@@ -13,6 +13,7 @@ function defaultContentNodeFields(source) {
     contentType: source.contentType?.node.name,
     label: source.title,
     date: source.dateGmt,
+    publishDate: source.dateGmt,
     year: source.dateGmt && formatDate(parseDate(source.dateGmt), "yyyy"),
     month: source.dateGmt && formatDate(parseDate(source.dateGmt), "yyyy-MM"),
     image: source.featuredImage?.node,


### PR DESCRIPTION
Making sure it's possible to sort by ` publishDate` by default. `date` is identical today, but might be used for dates other than the actual publish date.