### PR TITLE
fix: Use correct param when getting gallery images

### DIFF
--- a/packages/gatsby-theme-basic/src/components/modularity-modules/GalleryModule.js
+++ b/packages/gatsby-theme-basic/src/components/modularity-modules/GalleryModule.js
@@ -65,7 +65,7 @@ export default function GalleryModule({
 }) {
   const { t } = useTranslation();
 
-  let images = module?.modGalleryOptions?.modGalleryImages?.images;
+  let images = module?.modGalleryOptions?.modGalleryImages;
   let displaySettings = module?.settings?.display;
   let pauseOnHover = module?.settings?.pauseOnHover;
 


### PR DESCRIPTION
The image array for a gallery module is in `modGalleryOptions.modGalleryImages`, not `modGalleryOptions.modGalleryImages.images`. Corrected this to make the gallery module work.